### PR TITLE
Change net.imagej:imagej dependency's scope to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 			<url>https://imagej.net/User:Rueden</url>
 			<properties><id>ctrueden</id></properties>
 		</contributor>
+		<contributor>
+			<name>Stefan Helfrich</name>
+			<url>https://imagej.net/User:Stelfrich</url>
+			<properties><id>stelfrich</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
When the scope of a dependency is set to `provided`, executing `mvn install` with `-Dimagej.app.directory` will only copy the artifact instead of copying all dependencies of `net.imagej:imagej`.